### PR TITLE
 Migrate QSerenityString to the new AK::String

### DIFF
--- a/serenity/qserenitystring.cpp
+++ b/serenity/qserenitystring.cpp
@@ -6,12 +6,16 @@
 
 #include "qserenitystring.h"
 
-#include <AK/StdLibExtraDetails.h>
+#include <AK/Span.h>
+#include <AK/String.h>
+#include <AK/Error.h>
 
-AK::String QSerenityString::fromQString(const QString &str) {
-    return AK::String(str.toStdString().c_str());
+AK::ErrorOr<AK::String> QSerenityString::fromQString(const QString &str) {
+    const auto utf8_string = str.toUtf8();
+    return AK::String::from_utf8(AK::StringView(utf8_string.data(), utf8_string.size()));
 }
 
 QString QSerenityString::toQString(const AK::String &v) {
-    return QString(v.characters());
+    const auto bytes = v.bytes();
+    return QString::fromUtf8(reinterpret_cast<const char*>(bytes.data()), bytes.size());
 }

--- a/serenity/qserenitystring.h
+++ b/serenity/qserenitystring.h
@@ -8,15 +8,11 @@
 
 #define AK_DONT_REPLACE_STD
 
-#include <QtCore/private/qstringconverter_p.h>
-#include <forward_list>
-#include <AK/StdLibExtraDetails.h>
-#include <AK/String.h>
+#include <AK/Forward.h>
 #include <QString>
 
-class QSerenityString
+namespace QSerenityString
 {
-public:
-    static AK::String fromQString(const QString& str);
-    static QString toQString(const AK::String& v);
+    AK::ErrorOr<AK::String> fromQString(const QString& str);
+    QString toQString(const AK::String& v);
 };

--- a/serenity/qserenitywindow.cpp
+++ b/serenity/qserenitywindow.cpp
@@ -5,12 +5,11 @@
  */
 
 #include "qserenitywindow.h"
-
-#include <iostream>
-
-#include <private/qguiapplication_p.h>
-
+#include "qserenitystring.h"
+#include <AK/String.h>
 #include <Kernel/API/KeyCode.h>
+#include <iostream>
+#include <private/qguiapplication_p.h>
 
 static QMap<KeyCode, int> keyMap {
     { KeyCode::Key_Invalid, 0 },
@@ -134,7 +133,8 @@ QSerenityWindow::QSerenityWindow(QWindow *window)
     m_window->set_double_buffering_enabled(false);
 
     m_window->set_main_widget(m_proxyWidget);
-    m_window->set_title(QSerenityString::fromQString(window->title()));
+    const auto title = MUST(QSerenityString::fromQString(window->title()));
+    m_window->set_title(title.to_deprecated_string());
     m_window->show();
 
     std::cerr << "Native window set up\n";
@@ -142,7 +142,8 @@ QSerenityWindow::QSerenityWindow(QWindow *window)
 
 void QSerenityWindow::setWindowTitle(const QString &text)
 {
-    m_window->set_title(QSerenityString::fromQString(text));
+    const auto title = MUST(QSerenityString::fromQString(text));
+    m_window->set_title(title.to_deprecated_string());
 }
 
 QRect QSerenityWindow::geometry() const {


### PR DESCRIPTION
This fixes build errors with the new `AK::String`.
I've also reduced the includes a bit and changed the QSerenityString into a namespace.